### PR TITLE
Talker IDs for Galieo, BeiDou, GLONASS, and GNSS

### DIFF
--- a/src/rs232.rs
+++ b/src/rs232.rs
@@ -110,7 +110,9 @@ impl RS232 {
 
         for _ in 1..3 {
             if let Ok(_) = self.read_line(&mut buffer) {
-                if buffer.starts_with("$GP") {
+                if buffer.len() >= 15 && buffer.starts_with("$G") &&
+                    buffer.chars().nth(6).unwrap() == ','
+                {
                     return true;
                 }
 


### PR DESCRIPTION
Support more Talker ID prefixes from NMEA 4.1 other than just GPS.

Partly resolves issue #5. (See also the corresponding [patch for GeoClue](https://bugs.freedesktop.org/show_bug.cgi?id=104691).)