### PR TITLE
Stop disabling SELinux

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ gps-share is targetted specifically for Linux. It may or may not work on other
 POSIX hosts. Patches to add/fix support for non-Linux systems, are more than
 welcome.
 
-On Fedora, you might need to either disable selinux or configure it to allow
-gps-share to start and announce a TCP service.
+Remember to configure your firewall to allow your service to be reachable on the
+local network, as needed.
 
 ## Building from source
 


### PR DESCRIPTION
Reducing system security is the wrong advise.

`gps-share` runs unconstrained, so you don’t need to disable SELinux for it to work. (FirewallD is another matter.)

As far as I can tell, the only SELinux policy issue is the following:

    type=AVC msg=audit(1516309779.425:5202): avc:  denied  { name_connect } for  pid=27477 comm="geoclue" dest=38103 scontext=system_u:system_r:geoclue_t:s0 tcontext=system_u:object_r:ephemeral_port_t:s0 tclass=tcp_socket permissive=1

Work around it with the following policy:

    allow geoclue_t ephemeral_port_t:tcp_socket name_connect;

Upstream bugs:

https://bugzilla.redhat.com/show_bug.cgi?id=1362118
https://github.com/firewalld/firewalld/pull/284