### PR TITLE
Use TCP port 10110 by default

### DIFF
--- a/src/cmdline_config.rs
+++ b/src/cmdline_config.rs
@@ -42,7 +42,7 @@ pub fn config_from_cmdline() -> Config {
             Arg::with_name("port")
                 .short("p")
                 .long("--port")
-                .help("Port to run TCP service on")
+                .help("Port to run TCP service on (default: 10110)")
                 .takes_value(true)
                 .value_name("PORT"),
         )
@@ -68,7 +68,7 @@ pub fn config_from_cmdline() -> Config {
     let dev_path = matches.value_of("device").and_then(|p| {
         Some(::std::path::PathBuf::from(p))
     });
-    let port: u16 = matches.value_of("port").unwrap_or("0").parse().unwrap_or(0);
+    let port: u16 = matches.value_of("port").unwrap_or("10110").parse().unwrap_or(0);
     let iface = matches.value_of("interface").map(|s| s.to_string());
     let baudrate = matches
         .value_of("baudrate")

--- a/src/cmdline_config.rs
+++ b/src/cmdline_config.rs
@@ -50,7 +50,7 @@ pub fn config_from_cmdline() -> Config {
             Arg::with_name("interface")
                 .short("n")
                 .long("--network-interface")
-                .help("Bind specific network interface")
+                .help("Bind specific network interface (default: all)")
                 .takes_value(true)
                 .value_name("INTERFACE"),
         )

--- a/tests/stdin_gps.rs
+++ b/tests/stdin_gps.rs
@@ -26,13 +26,8 @@ use std::io::Read;
 use std::net::TcpStream;
 
 #[test]
-fn test_stdin_gps_autoport() {
+fn test_stdin_gps_defaults() {
     test_stdin_gps(None, None);
-}
-
-#[test]
-fn test_stdin_gps_autoport_iface() {
-    test_stdin_gps(None, Some("lo"));
 }
 
 #[test]
@@ -42,7 +37,7 @@ fn test_stdin_gps_with_port() {
 
 #[test]
 fn test_stdin_gps_with_port_iface() {
-    test_stdin_gps(None, Some("lo"));
+    test_stdin_gps(Some(9315), Some("lo"));
 }
 
 fn test_stdin_gps(tcp_port: Option<u16>, net_iface: Option<&str>) {


### PR DESCRIPTION
Standard nmea-0183 service port as registered with IANA.

Resolves issue #9.