### PR TITLE
Remove Talker ID test from verify

### DIFF
--- a/src/rs232.rs
+++ b/src/rs232.rs
@@ -110,7 +110,8 @@ impl RS232 {
 
         for _ in 1..3 {
             if let Ok(_) = self.read_line(&mut buffer) {
-                if buffer.len() >= 15 && buffer.starts_with("$G") &&
+                if buffer.len() >= 15 &&
+                    buffer.chars().nth(0) == Some('$') &&
                     buffer.chars().nth(6) == Some(',')
                 {
                     return true;


### PR DESCRIPTION
Turns out Talker IDs don’t have to start with "$G" as I first believed. BeiDou identifies as either "$GB" or "$BD". Likewise, QZSS as either "$GP" (shared ID with GPS) or "$QZ" . Other Talker IDs less relevant to positional data that don’t start with G also exist.