### PR TITLE
libc: Use generic c_char type

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -94,7 +94,7 @@ impl Config {
                 libc::AF_INET6 => size = mem::size_of::<libc::sockaddr_in6>() as u32,
                 _ => continue,
             };
-            let host_ptr = host.into_raw() as *mut i8;
+            let host_ptr = host.into_raw() as *mut libc::c_char;
             let ret = libc::getnameinfo(
                 addr.ifa_addr,
                 size,


### PR DESCRIPTION
For unknown reasons, the Rust libc bindings disagree between signed and
unsigned char among different cpu architectures.
E.g. 32- and 64-bit ARM translate char to u8, while amd64 uses i8.

By using the c_char type provided by the libc bindings, this issue can
be avoided in a cpu and os independent way.

Fixes #13 

Signed-off-by: Josua Mayer <josua@solid-run.com>