### PR TITLE
avahi: Port to zbus

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ description = "Utility to share your GPS device on local network"
 
 [dependencies]
 serial = "0.3"
-dbus = "^0.5"
-dbus-macros = "0.2.3"
+zbus = "1.8"
+zvariant = "2.6"
 signal-hook = "0.1.13"
 clap = "2.23.1"
 libc = "^0.2.21"

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,16 +31,15 @@ mod gnss;
 mod server;
 mod stdin_gps;
 
-extern crate dbus;
 extern crate serial;
-#[macro_use]
-extern crate dbus_macros;
+
 extern crate core;
 extern crate clap;
 extern crate libc;
 extern crate libudev;
 extern crate signal_hook;
-
+extern crate zbus;
+extern crate zvariant;
 
 use config::Config;
 use gps::GPS;


### PR DESCRIPTION
This drops dependencies on dbus-macros. In comes zbus and zvariant. Seems to appear in `avahi-browse --all` like before.