### PR TITLE
CI: Update tests invocation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ branches:
     except:
         - /^wip\/.*/
 
+script:
+  - cargo build --verbose
+  - cargo test --verbose -- --test-threads=1
+
 addons:
   apt:
     packages:


### PR DESCRIPTION
Travis tries to parallelize tests by default, whereas end-to-end tests use shared resources, and can't be parallelized.

Inspired by https://docs.travis-ci.com/user/languages/rust/#default-build-script

This hasn't been tested in any way, I'm not sure how to link this commit to Travis.