### PR TITLE
test: Fix reference to gps-share binary

### DIFF
--- a/tests/stdin_gps.rs
+++ b/tests/stdin_gps.rs
@@ -51,7 +51,7 @@ fn stdin_gps() {
 }
 
 fn test_stdin_gps(tcp_port: Option<u16>, net_iface: Option<&str>, local_socket: LocalSocket) {
-    let mut cmd = Command::new("target/debug/gps-share");
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_gps-share"));
 
     cmd.arg("-a")
         .arg("-")


### PR DESCRIPTION
The path to the binary under test is passed via an environment variable, so there's no need to guess its location.